### PR TITLE
Downloads! Fixes #21

### DIFF
--- a/addon_catalog.plugin.php
+++ b/addon_catalog.plugin.php
@@ -500,6 +500,8 @@ class AddonCatalogPlugin extends Plugin {
 
 			unset( $post );
 			$post = Post::create( $post_fields );
+			$post->info->hoster = $info[ 'hoster' ];
+			$post->update();
 
 			EventLog::log( _t( 'Created post #%s - %s', array( $post->id, $post->title ) ), 'info' );
 		}

--- a/addon_catalog.plugin.php
+++ b/addon_catalog.plugin.php
@@ -839,6 +839,10 @@ class AddonCatalogPlugin extends Plugin {
 						
 						// This will get a prepared command string, including the url, leaving space to insert the destination
 						$clonecommand = Plugins::filter( 'addon_download_command', $addon->info->hoster, $term->info->url );
+						if(!isset($clonecommand) || empty($clonecommand)) {
+							Utils::debug($addon, $term);
+							return;
+						}
 						exec(sprintf($clonecommand, sys_get_temp_dir() . '/' . $addon->slug));
 						exec('cd ' . sys_get_temp_dir() . '/' . $addon->slug . '/ && zip -r ' . Site::get_dir('user') . $file . ' *');
 					}

--- a/addon_catalog.plugin.php
+++ b/addon_catalog.plugin.php
@@ -837,8 +837,9 @@ class AddonCatalogPlugin extends Plugin {
 							mkdir( Site::get_dir('user') . $dir, 0755, true );
 						}
 						
-						// This should be replaced by the according commands for each service
-						exec('git clone ' . $term->info->url . ' ' . sys_get_temp_dir() . '/' . $addon->slug);
+						// This will get a prepared command string, including the url, leaving space to insert the destination
+						$clonecommand = Plugins::filter( 'addon_download_command', $addon->info->hoster, $term->info->url );
+						exec(sprintf($clonecommand, sys_get_temp_dir() . '/' . $addon->slug));
 						exec('cd ' . sys_get_temp_dir() . '/' . $addon->slug . '/ && zip -r ' . Site::get_dir('user') . $file . ' *');
 					}
 				}


### PR DESCRIPTION
Provide downloadable zip files for addon versions. Always serve a copy of the latest commit, don't keep older commits of that version. Server the files via the existing download link.
