### PR TITLE
Remove the trailing slash added to $basepath

### DIFF
--- a/addon_catalog.plugin.php
+++ b/addon_catalog.plugin.php
@@ -198,7 +198,7 @@ class AddonCatalogPlugin extends Plugin {
 	public function filter_default_rewrite_rules ( $rules ) {
 
 		if ( Options::get( 'addon_catalog__use_basepath', false ) ) {
-			$basepath = Options::get( 'addon_catalog__basepath', 'explore' ) . "/";
+			$basepath = Options::get( 'addon_catalog__basepath', 'explore' );
 		}
 		else {
 			$basepath = "";
@@ -234,8 +234,8 @@ class AddonCatalogPlugin extends Plugin {
 		// create the post display rule for one addon
 		$rule = array(
 			'name' => "display_addon",
-			'parse_regex' => "#^{$basepath}(?P<addon>{$addon_regex})/(?P<slug>[^/]+)/?$#i",
-			'build_str' => $basepath . '{$addon}/{$slug}',
+			'parse_regex' => "#^{$basepath}/(?P<addon>{$addon_regex})/(?P<slug>[^/]+)/?$#i",
+			'build_str' => $basepath . '/{$addon}/{$slug}',
 			'handler' => 'PluginHandler',
 			'action' => 'display_addon',
 			'parameters' => serialize( array( 'require_match' => array( 'Posts', 'rewrite_match_type' ), 'content_type' => 'addon' ) ),
@@ -246,8 +246,8 @@ class AddonCatalogPlugin extends Plugin {
 		// create the rule for downloading an addon as a zip
 		$rule = array(
 			'name' => "download_addon",
-			'parse_regex' => "#^{$basepath}(?P<addon>{$addon_regex})/(?P<slug>[^/]+)/download/(?P<version>[^/]+)/?$#i",
-			'build_str' => $basepath . '{$addon}/{$slug}/download/{$version}',
+			'parse_regex' => "#^{$basepath}/(?P<addon>{$addon_regex})/(?P<slug>[^/]+)/download/(?P<version>[^/]+)/?$#i",
+			'build_str' => $basepath . '/{$addon}/{$slug}/download/{$version}',
 			'handler' => 'PluginHandler',
 			'action' => 'download_addon',
 			'parameters' => '',
@@ -258,8 +258,8 @@ class AddonCatalogPlugin extends Plugin {
 		// create the addon post display rule for multiple addons
 		$rule = array(
 			'name' => "display_addons",
-			'parse_regex' => "%^{$basepath}(?P<addon>{$addon_regex})(?:/page/(?P<page>\d+))?/?$%",
-			'build_str' => $basepath . '{$addon}(/page/{$page})',
+			'parse_regex' => "%^{$basepath}/(?P<addon>{$addon_regex})(?:/page/(?P<page>\d+))?/?$%",
+			'build_str' => $basepath . '/{$addon}(/page/{$page})',
 			'handler' => 'PluginHandler',
 			'action' => "display_addons",
 			'priority' => 2,


### PR DESCRIPTION
Shouldn't be there, and if it is the basepath page won't load. Add the slash to the rewrite rules that need them directly.
